### PR TITLE
fix: remove checkmarks from issue template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,10 +23,11 @@ encryptContent('my data')
 For details refer to issue #123
 
 ## Type of Change
-- [ ] New feature
-- [ ] Bug fix
-- [ ] API reference/documentation update
-- [ ] Other
+<!-- Explain or annotate the nature of your changes, see examples below -->
+- New feature
+- Bug fix
+- API reference/documentation update
+- Other 
 
 ## Does this introduce a breaking change?
 List the APIs or describe the functionality that this PR breaks.


### PR DESCRIPTION
A pet peeve of mine is when PRs are created that check one of these options without deleting the rest. 
This results in a useless _1 of 4 tasks complete_ annotation. 